### PR TITLE
Add ant build file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,40 @@
+<project name="Dilema-Generator" default="jar">
+
+	<property name="src.dir"	value="src"/>
+	<property name="build.dir" 	value="bin"/>
+	<property name="classes.dir"	value="${build.dir}/classes"/>
+	<property name="jar.dir"	value="${build.dir}/jar"/>
+	<property name="main-class"	value="main/Main"/>
+
+	<target name="clean">
+		<delete dir="${build.dir}"/>
+	</target>
+
+	<target name="compile">
+		<mkdir dir="${classes.dir}"/>
+		<javac srcdir="${src.dir}" destdir="${classes.dir}">
+			<classpath>
+				<fileset dir=".">
+					<include name="*.jar"/>
+				</fileset>
+			</classpath>
+		</javac>
+	</target>
+
+	<target name="jar" depends="compile">
+		<mkdir dir="${jar.dir}"/>
+		<jar destfile="${jar.dir}/${ant.project.name}.jar" basedir="${classes.dir}">
+			<manifest>
+				<attribute name="Main-Class" value="${main-class}"/>
+			</manifest>
+		</jar>
+	</target>
+
+	<target name="run" depends="jar">
+		<java jar="${jar.dir}/${ant.project.name}.jar" fork="true"/>
+	</target>
+
+	<target name="clean-build" depends="clean,jar"/>
+
+	<target name="main" depends="clean,run"/>
+</project>


### PR DESCRIPTION
Para adicionar um "modelo de compilação" que antecede o maven, não é necessário utilizar nenhuma IDE para compilar e rodar o programa, apenas o apache-ant.
Com os comandos:
- ant clean-build
- ant run
Ele compila, monta um jar e executa o Dilema-Generator.jar